### PR TITLE
AG-27: Fix Cloud Build Issue with Uvicorn Executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ COPY . /app
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install Uvicorn for ASGI support
+RUN pip install uvicorn
+
 # Make port 8080 available to the world outside this container
 EXPOSE 8080
 


### PR DESCRIPTION
This PR addresses the issue where the Cloud Build process fails due to the uvicorn executable not being found in the PATH. The Dockerfile has been updated to ensure that uvicorn is installed correctly.

### Test Plan

pytest